### PR TITLE
Ingest curriculum info, offer via API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Make k8s configuration configurable at Antidote level [#159](https://github.com/nre-learning/antidote-core/pull/159)
 - Changed resource order on ingest, and added early return on error [#160](https://github.com/nre-learning/antidote-core/pull/160)
 - Add "Authors" to lesson metadata [#162](https://github.com/nre-learning/antidote-core/pull/162)
+- Ingest curriculum info, offer via API [#163](https://github.com/nre-learning/antidote-core/pull/163)
 
 ## v0.5.1 - February 17, 2020
 

--- a/api/exp/curricula.go
+++ b/api/exp/curricula.go
@@ -24,8 +24,10 @@ func (s *AntidoteAPI) GetCurriculumInfo(ctx context.Context, filter *pb.Curricul
 	}
 
 	return &pb.CurriculumInfo{
-		Name:        curriculum.Slug,
+		Name:        curriculum.Name,
 		Description: curriculum.Description,
 		Website:     curriculum.Website,
+		AVer:        curriculum.AVer,
+		GitRoot:     curriculum.GitRoot,
 	}, nil
 }

--- a/api/exp/definitions/curriculum.proto
+++ b/api/exp/definitions/curriculum.proto
@@ -1,8 +1,6 @@
 syntax = "proto3";
 package antidote.api.exp;
 
-import "lesson.proto";
-import "collection.proto";
 import "google/api/annotations.proto";
 
 service CurriculumService {
@@ -22,14 +20,7 @@ message CurriculumInfo {
     string Name = 1;
     string Description = 2;
     string Website = 3;
+    string AVer = 4;
+    string GitRoot = 5;
 }
 
-// The full curriculum, including both metadata and loaded resources.
-message Curriculum {
-    string Name = 1;
-    string Description = 2;
-    string Website = 3;
-
-    map<int32, Lesson> Lessons = 4;
-    map<int32, Collection> Collections = 5;
-}

--- a/api/exp/definitions/curriculum.swagger.json
+++ b/api/exp/definitions/curriculum.swagger.json
@@ -46,6 +46,12 @@
         },
         "Website": {
           "type": "string"
+        },
+        "AVer": {
+          "type": "string"
+        },
+        "GitRoot": {
+          "type": "string"
         }
       },
       "description": "Use this to return only metadata about the installed curriculum."

--- a/api/exp/livelessons.go
+++ b/api/exp/livelessons.go
@@ -99,6 +99,7 @@ func (s *AntidoteAPI) RequestLiveLesson(ctx context.Context, lp *pb.LiveLessonRe
 		if ll.SessionID == lp.SessionId && ll.LessonSlug == lp.LessonSlug {
 			existingLL = &ll
 			llExists = true
+			break
 		}
 	}
 

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -307,6 +307,12 @@ Curriculum = `{
         },
         "Website": {
           "type": "string"
+        },
+        "AVer": {
+          "type": "string"
+        },
+        "GitRoot": {
+          "type": "string"
         }
       },
       "description": "Use this to return only metadata about the installed curriculum."

--- a/cmd/antidote/main.go
+++ b/cmd/antidote/main.go
@@ -34,7 +34,13 @@ func main() {
 					Tier:          "local",
 				}
 
-				_, err := ingestors.ReadImages(cfg)
+				_, err := ingestors.ReadCurriculum(cfg)
+				if err != nil {
+					color.Red("Some curriculum resources failed to validate.")
+					os.Exit(1)
+				}
+
+				_, err = ingestors.ReadImages(cfg)
 				if err != nil {
 					color.Red("Some curriculum resources failed to validate.")
 					os.Exit(1)

--- a/db/driver_inmem.go
+++ b/db/driver_inmem.go
@@ -243,7 +243,7 @@ func (a *ADMInMem) SetCurriculum(sc ot.SpanContext, curriculum *models.Curriculu
 	span.LogFields(log.Object("curriculum", curriculum))
 
 	a.curriculumMu.Lock()
-	defer a.collectionsMu.Unlock()
+	defer a.curriculumMu.Unlock()
 	a.curriculum = curriculum
 	return nil
 }

--- a/db/ingestors/curriculum.go
+++ b/db/ingestors/curriculum.go
@@ -1,9 +1,16 @@
 package db
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
 	"github.com/nre-learning/antidote-core/config"
 	"github.com/nre-learning/antidote-core/db"
+	models "github.com/nre-learning/antidote-core/db/models"
 	ot "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 // ImportCurriculum provides a single function for all curriculum resources to be imported and placed
@@ -12,9 +19,12 @@ func ImportCurriculum(dm db.DataManager, cfg config.AntidoteConfig) error {
 	span := ot.StartSpan("ingestor_curriculum_import")
 	defer span.Finish()
 
-	// There is a model for a Curriculum type, but we're still figuring out if/how we want to
-	// use that, so I'm leaving it out for now. This is where we would likely import it, and perhaps also
-	// do checks like version compatibility with Antidote version, etc.
+	// TODO(mierdin): Enforce a version check with the curriculum when loaded
+	curriculum, err := ReadCurriculum(cfg)
+	if err != nil {
+		return err
+	}
+	dm.SetCurriculum(span.Context(), curriculum)
 
 	collections, err := ReadCollections(cfg)
 	if err != nil {
@@ -35,4 +45,37 @@ func ImportCurriculum(dm db.DataManager, cfg config.AntidoteConfig) error {
 	dm.InsertLessons(span.Context(), lessons)
 
 	return nil
+}
+
+func ReadCurriculum(cfg config.AntidoteConfig) (*models.Curriculum, error) {
+
+	curriculumFilePath := fmt.Sprintf("%s/curriculum.meta.yaml", cfg.CurriculumDir)
+	log.Infof("Attempting to read curriculum information from %s", curriculumFilePath)
+
+	if _, err := os.Stat(curriculumFilePath); err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	yamlDef, err := ioutil.ReadFile(curriculumFilePath)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	var curriculum models.Curriculum
+	err = yaml.Unmarshal([]byte(yamlDef), &curriculum)
+	if err != nil {
+		log.Error(err)
+		return nil, err
+	}
+
+	if !curriculum.JSValidate() {
+		log.Errorf("Basic schema validation failed on %s - see log for errors.", curriculum.Name)
+		return nil, errBasicValidation
+	}
+
+	log.Info("Curriculum information loaded.")
+
+	return &curriculum, nil
 }

--- a/db/models/curriculum.go
+++ b/db/models/curriculum.go
@@ -1,9 +1,51 @@
 package db
 
+import (
+	"encoding/json"
+
+	jsonschema "github.com/alecthomas/jsonschema"
+	log "github.com/sirupsen/logrus"
+	gjs "github.com/xeipuuv/gojsonschema"
+)
+
 // Curriculum is a resource type that defines a bit of meta-data for a Curriculum as a whole.
 type Curriculum struct {
-	Slug        string `json:"Slug" yaml:"slug" jsonschema:"Name of this curriculum"`
-	Description string `json:"Description" yaml:"description" jsonschema:"Description of this curriculum"`
-	Website     string `json:"Website" yaml:"website" jsonschema:"Website for this curriculum"`
-	AVer        string `json:"AVer" yaml:"aVer" jsonschema:"The version of Antidote this curriculum was built for"`
+	Name        string `json:"Name" yaml:"name" jsonschema:"minLength=1,description=Name of this curriculum"`
+	Description string `json:"Description" yaml:"description" jsonschema:"minLength=1,description=Description of this curriculum"`
+	Website     string `json:"Website" yaml:"website" jsonschema:"minLength=1,description=Website for this curriculum"`
+	AVer        string `json:"AVer" yaml:"aVer" jsonschema:"minLength=1,description=The version of Antidote this curriculum was built for"`
+	GitRoot     string `json:"GitRoot" yaml:"gitRoot" jsonschema:"minLength=1,description=The web URL to the repository that houses this curriculum"`
+}
+
+// JSValidate uses an Antidote resource's struct properties and tags to construct a jsonschema
+// document, and then validates that instance's values against that schema.
+func (c Curriculum) JSValidate() bool {
+
+	// Load JSON Schema document for type
+	schemaReflect := jsonschema.Reflect(c)
+	b, _ := json.Marshal(schemaReflect)
+	schemaLoader := gjs.NewStringLoader(string(b))
+	schema, _ := gjs.NewSchema(schemaLoader)
+
+	// Load instance JSON document
+	b, err := json.Marshal(c)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+	documentLoader := gjs.NewStringLoader(string(b))
+
+	// Perform validation
+	result, err := schema.Validate(documentLoader)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	validationErrors := result.Errors()
+	for j := range validationErrors {
+		log.Errorf("Validation error - %s", validationErrors[j].String())
+	}
+
+	return result.Valid()
 }

--- a/db/test/test-curriculum/curriculum.meta.yaml
+++ b/db/test/test-curriculum/curriculum.meta.yaml
@@ -1,0 +1,6 @@
+name: antidote-test-curriculum
+description: A test curriculum for the Antidote platform
+website: https://nrelabs.io
+aVer: 0.6.0
+gitRoot: https://github.com/nre-learning/antidote-test-curriculum
+

--- a/hack/mocks/curriculum.meta.yaml
+++ b/hack/mocks/curriculum.meta.yaml
@@ -1,0 +1,6 @@
+name: antidote-test-curriculum
+description: A test curriculum for the Antidote platform
+website: https://nrelabs.io
+aVer: 0.6.0
+gitRoot: https://github.com/nre-learning/antidote-test-curriculum
+


### PR DESCRIPTION
https://github.com/nre-learning/antidote-ui-components/pull/19 required additional information about the loaded curriculum, so I decided it was time to formally add a metadata file for the curriculum as a whole, and add it to the ingestion pipeline.

I am also adding the new fields to the API so that the front-end can consume them.