### PR TITLE
Add links to object ref documentation wherever possible in creation wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add "Authors" to lesson metadata [#162](https://github.com/nre-learning/antidote-core/pull/162)
 - Ingest curriculum info, offer via API [#163](https://github.com/nre-learning/antidote-core/pull/163)
 - Add functionality to attach a pullsecret to pods (allows private image pulls) [#164](https://github.com/nre-learning/antidote-core/pull/164)
+- Add links to object ref documentation wherever possible in creation wizard [#165](https://github.com/nre-learning/antidote-core/pull/165)
 
 ## v0.5.1 - February 17, 2020
 

--- a/cmd/antidote/clihelpers.go
+++ b/cmd/antidote/clihelpers.go
@@ -26,11 +26,12 @@ func askSimpleValue(prompt, defaultValue, help string) string {
 	return resp
 }
 
-func simpleConfirm(msg string) bool {
+func simpleConfirm(msg, help string) bool {
 	var val survey.Validator
 	resp := false
 	prompt := &survey.Confirm{
 		Message: msg,
+		Help:    help,
 	}
 	err := survey.AskOne(prompt, &resp, val)
 	if err == terminal.InterruptErr {

--- a/cmd/antidote/wizard.go
+++ b/cmd/antidote/wizard.go
@@ -151,11 +151,11 @@ func schemaWizard(schema *jsonschema.Schema, root, typePrefix string) (map[strin
 			subTypeName := splitSlice[len(splitSlice)-1]
 
 			if v.MinItems == 0 {
-				if !simpleConfirm(fmt.Sprintf("--- Do you wish to create any %s? ---", typeName)) {
+				if !simpleConfirm(fmt.Sprintf("--- Do you wish to create any %s? ---", typeName), v.Description) {
 					continue
 				}
 			}
-			color.Yellow("You will now be prompted to create a series of %s (%s)\n", typeName, v.Description)
+			color.Yellow("You will now be prompted to create a series of %s\n%s\n", typeName, v.Description)
 
 			var members []interface{}
 
@@ -164,7 +164,7 @@ func schemaWizard(schema *jsonschema.Schema, root, typePrefix string) (map[strin
 				innerMap, _ := schemaWizard(schema, subTypeName, fmt.Sprintf("%s[%d].", typeName, i))
 				members = append(members, innerMap)
 
-				if !simpleConfirm(fmt.Sprintf("--- Do you want to add more %s? ---", typeName)) {
+				if !simpleConfirm(fmt.Sprintf("--- Do you want to add more %s? ---", typeName), "Type 'y' to create additional items in this list") {
 					break
 				}
 

--- a/cmd/antidote/wizard.go
+++ b/cmd/antidote/wizard.go
@@ -26,7 +26,7 @@ func promptForValue(name string, value *jsonschema.Type) string {
 
 	pattern := ""
 	if value.Pattern != "" {
-		pattern = fmt.Sprintf(", pattern: %s", value.Pattern)
+		pattern = fmt.Sprintf(",pattern='%s'", value.Pattern)
 	}
 	valueType := value.Type
 	if valueType == "array" {

--- a/db/models/lesson.go
+++ b/db/models/lesson.go
@@ -11,11 +11,11 @@ import (
 // Lesson represents the fields and sub-types for defining a lesson resource in Antidote
 type Lesson struct {
 	Name             string              `json:"Name" yaml:"name" jsonschema:"minLength=1,description=Human-readable name/title for the lesson"`
-	Slug             string              `json:"Slug" yaml:"slug" jsonschema:"minLength=1,description=A unique identifier for the lesson, usually 2-3 words with hyphens,pattern=^[a-z-]*$"`
+	Slug             string              `json:"Slug" yaml:"slug" jsonschema:"minLength=1,description=A unique identifier for the lesson (usually 2-3 lower-case words with hyphens),pattern=^[a-z-]*$"`
 	Category         string              `json:"Category" yaml:"category" jsonschema:"minLength=1,description=The name for the Category in which this lesson should belong,enum=fundamentals,enum=tools,enum=workflows"`
 	Diagram          string              `json:"Diagram" yaml:"diagram" jsonschema:"description=A public URL to lesson diagram"`
 	Video            string              `json:"Video" yaml:"video" jsonschema:"description=YouTube URL to lesson video"`
-	Tier             string              `json:"Tier" yaml:"tier" jsonschema:"description=Tier for this lesson (you probably want 'prod') ,enum=prod,enum=ptr,enum=local"`
+	Tier             string              `json:"Tier" yaml:"tier" jsonschema:"minLength=1,description=Tier for this lesson (you probably want 'prod') ,enum=prod,enum=ptr,enum=local"`
 	Collection       string              `json:"Collection,omitempty" yaml:"collection,omitempty" jsonschema:"description=The slug for the collection this lesson should belong to"`
 	Description      string              `json:"Description" yaml:"description" jsonschema:"minLength=1,description=A helpful description for what the learner should expect to get from this lesson"`
 	ShortDescription string              `json:"ShortDescription" yaml:"shortDescription" jsonschema:"minLength=1,description=A brief description for this lesson. One or two words"`
@@ -59,7 +59,7 @@ type LessonEndpoint struct {
 	Name  string `json:"Name" yaml:"name" jsonschema:"description=Name of the endpoint"`
 	Image string `json:"Image" yaml:"image" jsonschema:"description=The Image ref this endpoint uses,pattern=^[A-Za-z0-9\\-]*$"`
 
-	ConfigurationType string `json:"ConfigurationType,omitempty" yaml:"configurationType,omitempty" jsonschema:"enum=,enum=napalm,enum=python,enum=ansible"`
+	ConfigurationType string `json:"ConfigurationType,omitempty" yaml:"configurationType,omitempty" jsonschema:"description=Method for configuring this endpoint at runtime,enum=,enum=napalm,enum=python,enum=ansible"`
 
 	// Since we're starting to use the filename to derive certain things about configuration (i.e.
 	// which NAPALM driver to use) we will store the filename (only the name, no path) here on ingest

--- a/db/models/lesson.go
+++ b/db/models/lesson.go
@@ -21,10 +21,10 @@ type Lesson struct {
 	ShortDescription string              `json:"ShortDescription" yaml:"shortDescription" jsonschema:"minLength=1,description=A brief description for this lesson. One or two words"`
 	Prereqs          []string            `json:"Prereqs,omitempty" yaml:"prereqs,omitempty" jsonschema:"description=A list of slugs for other lessons that are prerequisite to this lesson"`
 	Tags             []string            `json:"Tags,omitempty" yaml:"tags,omitempty" jsonschema:"description=A list of tags to apply to this lesson for categorization purposes"`
-	Stages           []*LessonStage      `json:"Stages" yaml:"stages" jsonschema:"minItems=1,description=Logical sections or chapters of a lesson,additionalProperties=false"`
-	Endpoints        []*LessonEndpoint   `json:"Endpoints" yaml:"endpoints" jsonschema:"minItems=1,description=An instance of a software image to be made available in the lesson"`
-	Connections      []*LessonConnection `json:"Connections,omitempty" yaml:"connections,omitempty" jsonschema:"description=Specifies which endpoints should be connected to each other in the topology"`
-	Authors          []*LessonAuthor     `json:"Authors,omitempty" yaml:"authors,omitempty" jsonschema:"description=A list of authors for this lesson"`
+	Stages           []*LessonStage      `json:"Stages" yaml:"stages" jsonschema:"minItems=1,description=(Logical sections or chapters of a lesson)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/stages,additionalProperties=false"`
+	Endpoints        []*LessonEndpoint   `json:"Endpoints" yaml:"endpoints" jsonschema:"minItems=1,description=(An instance of a software image to be made available in the lesson)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/endpoints"`
+	Connections      []*LessonConnection `json:"Connections,omitempty" yaml:"connections,omitempty" jsonschema:"description=(Connections between endpoints in the topology)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/connections"`
+	Authors          []*LessonAuthor     `json:"Authors,omitempty" yaml:"authors,omitempty" jsonschema:"description=(A list of individuals that have contributed to this lesson)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/authors"`
 
 	// NOTE - any time you see these dashes, it means this field is used for internal purposes only.
 	// When we were using protobuf models for everything, we couldn't do this. But by separating internal
@@ -68,7 +68,7 @@ type LessonEndpoint struct {
 
 	AdditionalPorts []int32 `json:"AdditionalPorts,omitempty" yaml:"additionalPorts,omitempty" jsonschema:"description=Additional ports to open that aren't in a Presentation"`
 
-	Presentations []*LessonPresentation `json:"Presentations,omitempty" yaml:"presentations,omitempty" jsonschema:"description=A way of giving the learner some kind of interactive access to this endpoint"`
+	Presentations []*LessonPresentation `json:"Presentations,omitempty" yaml:"presentations,omitempty" jsonschema:"description=(A mechanism for providing the user with interactive access to this endpoint)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/presentations"`
 }
 
 // LessonPresentation is a particular view into a LessonEndpoint. It's a way of specifying how an endpoint


### PR DESCRIPTION
/cc @arsonistgopher

Note that there are still some WIP updates to the docs for Antidote 0.6.0 and will be finished before the next release. The links contained here will still be valid, however.

