### PR TITLE
Minor modifications to facilitate antidote-web development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Ingest curriculum info, offer via API [#163](https://github.com/nre-learning/antidote-core/pull/163)
 - Add functionality to attach a pullsecret to pods (allows private image pulls) [#164](https://github.com/nre-learning/antidote-core/pull/164)
 - Add links to object ref documentation wherever possible in creation wizard [#165](https://github.com/nre-learning/antidote-core/pull/165)
+- Minor modifications to facilitate antidote-web development  [#166](https://github.com/nre-learning/antidote-core/pull/166)
 
 ## v0.5.1 - February 17, 2020
 

--- a/cmd/antictl/main.go
+++ b/cmd/antictl/main.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/fatih/color"
 	pb "github.com/nre-learning/antidote-core/api/exp/generated"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -20,7 +19,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "antictl"
 	app.Version = buildInfo["buildVersion"]
-	app.Usage = "Admin/debug tool for the Antidote platform"
+	app.Usage = "Admin/debug tool for the Antidote platform. Use at your own risk"
 	var host, port string
 
 	// Ensure the server/client versions are identical
@@ -39,9 +38,14 @@ func main() {
 		}
 
 		if info.GetBuildVersion() != buildInfo["buildVersion"] {
-			color.Red("ERROR - server/client version mismatch")
-			fmt.Printf("Server version is %s, client is %s\n", info.GetBuildVersion(), buildInfo["buildVersion"])
-			os.Exit(1)
+			// I removed the warnings below because most often, antictl is used during development, and it's
+			// not uncommon to have different dev versions, so this mismatch is expected and pointless to warn about.
+			// On top of this, it gets in the way of being able to use tools like jq for handling the output.
+			// Should rethink this - but for now I'm leaving it out.
+
+			// color.Red("WARNING - server/client version mismatch. Commands may not work or do what you expect.")
+			// fmt.Printf("Server version is %s, client is %s\n", info.GetBuildVersion(), buildInfo["buildVersion"])
+			// fmt.Println("You can avoid this problem by ensuring you are using the version of antictl that was compiled with the instance of antidoted you're connecting to")
 		}
 		return nil
 	}

--- a/cmd/antidoted/main.go
+++ b/cmd/antidoted/main.go
@@ -67,7 +67,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		nc, err := nats.Connect(nats.DefaultURL)
+		nc, err := nats.Connect(config.NATSUrl)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 
+	"github.com/nats-io/nats.go"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -60,6 +61,8 @@ type AntidoteConfig struct {
 	// your kubeconfig via K8sOutOfClusterConfigPath
 	K8sInCluster              bool   `yaml:"k8sInCluster"`
 	K8sOutOfClusterConfigPath string `yaml:"k8sOutOfClusterConfigPath"`
+
+	NATSUrl string `yaml:"natsUrl"`
 }
 
 func LoadConfig(configFile string) (AntidoteConfig, error) {
@@ -88,6 +91,7 @@ func LoadConfig(configFile string) (AntidoteConfig, error) {
 		},
 		K8sInCluster:              true,
 		K8sOutOfClusterConfigPath: "",
+		NATSUrl:                   nats.DefaultURL,
 	}
 
 	yamlDef, err := ioutil.ReadFile(configFile)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+
+	"github.com/nats-io/nats.go"
 )
 
 // Helper functions courtesy of the venerable Ben Johnson
@@ -66,6 +68,7 @@ func TestConfigJSON(t *testing.T) {
 		EnabledServices:           []string{"foobarsvc"},
 		K8sInCluster:              true,
 		K8sOutOfClusterConfigPath: "",
+		NATSUrl:                   nats.DefaultURL,
 	}
 
 	t.Log(antidoteConfig.JSON())


### PR DESCRIPTION
During development of https://github.com/nre-learning/antidote-web/pull/100, I had to make some modifications to antidote-core to facilitate a few things. This PR adds a configuration option to override the default NATS url, and also removes the version mismatch warning from `antictl` output.