### PR TITLE
Strip X-Frame-Options header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add functionality to attach a pullsecret to pods (allows private image pulls) [#164](https://github.com/nre-learning/antidote-core/pull/164)
 - Add links to object ref documentation wherever possible in creation wizard [#165](https://github.com/nre-learning/antidote-core/pull/165)
 - Minor modifications to facilitate antidote-web development  [#166](https://github.com/nre-learning/antidote-core/pull/166)
+- Strip X-Frame-Options header [#167](https://github.com/nre-learning/antidote-core/pull/167)
 
 ## v0.5.1 - February 17, 2020
 

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -42,9 +42,10 @@ func (s *AntidoteScheduler) createIngress(sc ot.SpanContext, nsName string, ep *
 				"ingress.kubernetes.io/ingress.class": "nginx",
 				// https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/ssl-services
 				// We only need this if the endpoint requires HTTPS termination.
-				"ingress.kubernetes.io/ssl-services":       ep.Name,
-				"ingress.kubernetes.io/ssl-redirect":       redir,
-				"ingress.kubernetes.io/force-ssl-redirect": redir,
+				"ingress.kubernetes.io/ssl-services":          ep.Name,
+				"ingress.kubernetes.io/ssl-redirect":          redir,
+				"ingress.kubernetes.io/force-ssl-redirect":    redir,
+				"ingress.kubernetes.io/configuration-snippet": "proxy_hide_header X-Frame-Options;",
 			},
 		},
 

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -42,9 +42,11 @@ func (s *AntidoteScheduler) createIngress(sc ot.SpanContext, nsName string, ep *
 				"ingress.kubernetes.io/ingress.class": "nginx",
 				// https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/ssl-services
 				// We only need this if the endpoint requires HTTPS termination.
-				"ingress.kubernetes.io/ssl-services":          ep.Name,
-				"ingress.kubernetes.io/ssl-redirect":          redir,
-				"ingress.kubernetes.io/force-ssl-redirect":    redir,
+				"ingress.kubernetes.io/ssl-services":       ep.Name,
+				"ingress.kubernetes.io/ssl-redirect":       redir,
+				"ingress.kubernetes.io/force-ssl-redirect": redir,
+
+				// Strip X-Frame-Options headers from http endpoints (these would prevent iframes)
 				"ingress.kubernetes.io/configuration-snippet": "proxy_hide_header X-Frame-Options;",
 			},
 		},

--- a/scheduler/namespaces.go
+++ b/scheduler/namespaces.go
@@ -123,6 +123,7 @@ func (s *AntidoteScheduler) createNamespace(sc ot.SpanContext, req services.Less
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nsName,
 			Labels: map[string]string{
+				"name":            nsName, // IMPORTANT - used by networkpolicy to restrict traffic
 				"liveLesson":      fmt.Sprintf("%s", req.LiveLessonID),
 				"liveSession":     fmt.Sprintf("%s", req.LiveSessionID),
 				"lessonSlug":      fmt.Sprintf("%s", ll.LessonSlug),


### PR DESCRIPTION
Some applications try to explicitly prevent iframe usage via the X-Frame-Options header. This obviously presents a problem for HTTP presentations. Rather than try to reconfigure the endpoint to not send this header (which will vary wildly from app to app) or run nginx in the endpoint to try to rewrite it (just one more thing to make endpoint creators do), we can just strip this header at the ingress level with a custom nginx rule.

I also added the name label back into namespaces - having this out broke networkpolicies