### PR TITLE
Fix livelesson leak / livesession bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Fix livelesson leak / livesession bug [#171](https://github.com/nre-learning/antidote-core/pull/171)
 
 ## v0.6.0 - April 18, 2020
 

--- a/db/driver_inmem.go
+++ b/db/driver_inmem.go
@@ -515,6 +515,7 @@ func (a *ADMInMem) UpdateLiveSessionPersistence(sc ot.SpanContext, lsID string, 
 func (a *ADMInMem) DeleteLiveSession(sc ot.SpanContext, id string) error {
 	span := ot.StartSpan("db_livesession_delete", ot.ChildOf(sc))
 	defer span.Finish()
+	span.SetTag("lsID", id)
 
 	a.liveSessionsMu.Lock()
 	defer a.liveSessionsMu.Unlock()


### PR DESCRIPTION
During GC, we identify the corresponding session ID of the livelesson we're about to clean up so that we can retrieve it from the datastore and then check it's `persistent` flag. If this call fails, it causes GC to fail outright, which results in any further GC attempts to be skipped. This means that once this initial failure has occurred, livelessons will continue to build and build without being cleaned up. Not great.

However, this is just a symptom of another problem, which is that we're currently not checking to see if a livesession has any existing livelessons before deleting it (which is frankly a big duh on my part). With a default setting of 24 hours for a livesession TTL, this isn't an "all the time" occurrence, but also not entirely unlikely. All it would take is someone launching a lesson from the same machine around the same time of day, and I've already noticed this happening twice this week. This means that once the livelesson GC comes around to delete the livelesson, the parent session isn't around, and the previous issue occurs.

This PR fixes both problems:

- Allow GC to continue in the event of a failure in this livesession lookup (or really any other lookup), as we shouldn't allow any errors to allow livelessons to continue ad infinitum anyways
- Fix the problem that started this by first checking to see if a livesession has any child livelessons, and only delete it if it doesn't.