### PR TITLE
Fix collection slug type in API model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix livelesson leak / livesession bug [#171](https://github.com/nre-learning/antidote-core/pull/171)
 - Allow travis to install binaries from vendored libs too [#172](https://github.com/nre-learning/antidote-core/pull/172)
+- Fix collection slug type in API model [#173](https://github.com/nre-learning/antidote-core/pull/173)
 
 ## v0.6.0 - April 18, 2020
 

--- a/api/exp/definitions/lesson.proto
+++ b/api/exp/definitions/lesson.proto
@@ -58,7 +58,7 @@ message Lesson {
   repeated string Prereqs = 13;
 
   repeated string Tags = 14;
-  int32 Collection = 15;
+  string Collection = 15;
   string Description = 16;
 
   // This is meant to fill: "How well do you know <ShortDescription>?"

--- a/api/exp/definitions/lesson.swagger.json
+++ b/api/exp/definitions/lesson.swagger.json
@@ -216,8 +216,7 @@
           }
         },
         "Collection": {
-          "type": "integer",
-          "format": "int32"
+          "type": "string"
         },
         "Description": {
           "type": "string"

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -640,8 +640,7 @@ Lesson = `{
           }
         },
         "Collection": {
-          "type": "integer",
-          "format": "int32"
+          "type": "string"
         },
         "Description": {
           "type": "string"


### PR DESCRIPTION
For the lesson API, collection slugs were still being defined as ints, and therefore left out of the DB->API translation function because of a type mismatch. This fixes this problem, and results in the collection slug showing up properly in a retrieved lesson, where applicable.