### PR TITLE
Revert back to upstream bridge CNI plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix livelesson leak / livesession bug [#171](https://github.com/nre-learning/antidote-core/pull/171)
 - Allow travis to install binaries from vendored libs too [#172](https://github.com/nre-learning/antidote-core/pull/172)
 - Fix collection slug type in API model [#173](https://github.com/nre-learning/antidote-core/pull/173)
+- Revert back to upstream bridge CNI plugin [#174](https://github.com/nre-learning/antidote-core/pull/174)
 
 ## v0.6.0 - April 18, 2020
 

--- a/scheduler/networks.go
+++ b/scheduler/networks.go
@@ -150,8 +150,8 @@ func (s *AntidoteScheduler) createNetwork(sc ot.SpanContext, netIndex int, netNa
 
 	networkArgs := fmt.Sprintf(`{
 			"name": "%s",
-			"type": "antibridge",
-			"plugin": "antibridge",
+			"type": "bridge",
+			"plugin": "bridge",
 			"bridge": "%s",
 			"forceAddress": false,
 			"hairpinMode": false,


### PR DESCRIPTION
Once upon a time, we were working on LLDP support. This required us to change things at multiple points in the stack, and at the time, we wanted to experiment with adding this to the `bridge` CNI plugin. For - I'll say "reasons" - we just built our own version of this plugin called `antibridge` and have been using it for over a year.

However, this was just one piece of the puzzle, and the other things that would have been required to support LLDP properly never came through, so this work hasn't even paid off yet.

I'm reverting back to using the `bridge` plugin in this PR. Future efforts to enable LLDP should be holistic, and we should also not use our own custom binary, but try to get the work merged upstream.

Closes #170 