### PR TITLE
Provide HEPS domain via LiveLesson API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix collection slug type in API model [#173](https://github.com/nre-learning/antidote-core/pull/173)
 - Revert back to upstream bridge CNI plugin [#174](https://github.com/nre-learning/antidote-core/pull/174)
 - Fix excessive span exports with stats package [#175](https://github.com/nre-learning/antidote-core/pull/175)
+- Provide HEPS domain via LiveLesson API [#176](https://github.com/nre-learning/antidote-core/pull/176)
 
 ## v0.6.0 - April 18, 2020
 

--- a/api/exp/definitions/livelesson.proto
+++ b/api/exp/definitions/livelesson.proto
@@ -61,6 +61,7 @@ message LivePresentation {
   string Name = 1;
   int32 Port = 2;
   string Type = 3;
+  string HepDomain = 4;
 }
 
 

--- a/api/exp/definitions/livelesson.swagger.json
+++ b/api/exp/definitions/livelesson.swagger.json
@@ -247,6 +247,9 @@
         },
         "Type": {
           "type": "string"
+        },
+        "HepDomain": {
+          "type": "string"
         }
       }
     },

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -993,6 +993,9 @@ Livelesson = `{
         },
         "Type": {
           "type": "string"
+        },
+        "HepDomain": {
+          "type": "string"
         }
       }
     },

--- a/config/config.go
+++ b/config/config.go
@@ -13,8 +13,15 @@ import (
 type AntidoteConfig struct {
 	InstanceID string `yaml:"instanceId"`
 
-	Tier     string `yaml:"tier"`
-	Domain   string `yaml:"domain"`
+	Tier string `yaml:"tier"`
+
+	// HepsDomain is the domain on which HEPS hostnames should be provisioned. This domain is used
+	// as the direct parent for any subdomains that are configured for ingresses that allow access to
+	// HTTP endpoints. Note that these subdomains automatically include the antidote instance ID, so
+	// it's safe to have multiple instances of antidote running with the same HepsDomain
+	// configured.
+	HEPSDomain string `yaml:"hepsDomain"`
+
 	ImageOrg string `yaml:"imageOrg"`
 	GRPCPort int    `yaml:"grpcPort"`
 	HTTPPort int    `yaml:"httpPort"`
@@ -70,7 +77,7 @@ func LoadConfig(configFile string) (AntidoteConfig, error) {
 	// Set a new config with defaults set where relevant
 	config := AntidoteConfig{
 		Tier:              "prod",
-		Domain:            "localhost",
+		HEPSDomain:        "localhost",
 		ImageOrg:          "antidotelabs",
 		GRPCPort:          50099,
 		HTTPPort:          8086,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -52,7 +52,7 @@ func TestConfigJSON(t *testing.T) {
 		InstanceID:                "foobar",
 		Tier:                      "prod",
 		ImageOrg:                  "antidotelabs",
-		Domain:                    "nrelabs.io",
+		HEPSDomain:                "heps.nrelabs.io",
 		GRPCPort:                  50099,
 		HTTPPort:                  8086,
 		LiveSessionTTL:            1440,

--- a/db/models/livelesson.go
+++ b/db/models/livelesson.go
@@ -42,9 +42,10 @@ type LiveEndpoint struct {
 // LivePresentation is a running instance of a LessonPresentation, with additional details
 // that are relevant at runtime.
 type LivePresentation struct {
-	Name string           `json:"Name"`
-	Port int32            `json:"Port"`
-	Type PresentationType `json:"Type"`
+	Name      string           `json:"Name"`
+	Port      int32            `json:"Port"`
+	Type      PresentationType `json:"Type"`
+	HepDomain string           `json:"HepDomain"`
 }
 
 // LiveLessonStatus is backed by a set of possible const values for livelesson statuses below

--- a/hack/mocks/sample-antidote-config.yml
+++ b/hack/mocks/sample-antidote-config.yml
@@ -1,7 +1,7 @@
 ---
 instanceId: "foobar"
 tier: "prod"
-domain: "nrelabs.io"
+hepsDomain: "heps.nrelabs.io"
 imageOrg: "antidotelabs" 
 curriculumDir:     "/usr/bin/curriculum" 
 enabledServices:

--- a/scheduler/ingresses.go
+++ b/scheduler/ingresses.go
@@ -25,11 +25,9 @@ func (s *AntidoteScheduler) createIngress(sc ot.SpanContext, nsName string, ep *
 
 	// temporary but functional hack to disable SSL redirection for selfmedicate
 	// (doesn't currently use HTTPS)
-	if s.Config.Domain == "antidote-local" || s.Config.Domain == "localhost" {
+	if s.Config.HEPSDomain == "antidote-local" || s.Config.HEPSDomain == "localhost" {
 		redir = "false"
 	}
-
-	ingressDomain := fmt.Sprintf("%s-%s-%s.heps.%s", nsName, ep.Name, p.Name, s.Config.Domain)
 
 	newIngress := v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -54,13 +52,13 @@ func (s *AntidoteScheduler) createIngress(sc ot.SpanContext, nsName string, ep *
 		Spec: v1beta1.IngressSpec{
 			TLS: []v1beta1.IngressTLS{
 				{
-					Hosts:      []string{ingressDomain},
+					Hosts:      []string{p.HepDomain},
 					SecretName: "tls-certificate",
 				},
 			},
 			Rules: []v1beta1.IngressRule{
 				{
-					Host: ingressDomain,
+					Host: p.HepDomain,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{

--- a/scheduler/namespaces.go
+++ b/scheduler/namespaces.go
@@ -220,6 +220,11 @@ func (s *AntidoteScheduler) PurgeOldLessons(sc ot.SpanContext) ([]string, error)
 
 // generateNamespaceName is a helper function for determining the name of our kubernetes
 // namespaces, so we don't have to do this all over the codebase and maybe get it wrong.
-func generateNamespaceName(antidoteId, liveLessonID string) string {
-	return fmt.Sprintf("%s-%s", antidoteId, liveLessonID)
+// Note that the nsName is used EVERYWHERE, and what's in it is pretty important, so change
+// this formatting with CAUTION. For instance, the antidoteId is how we disambiguate between
+// instances for HEPS domains. **MAKE SURE** that this formatting matches the creation of
+// nsName in the API server right before the initializeLiveEndpoints function.
+// TODO(mierdin): Make this less dependent on the honor system.
+func generateNamespaceName(antidoteID, liveLessonID string) string {
+	return fmt.Sprintf("%s-%s", antidoteID, liveLessonID)
 }


### PR DESCRIPTION
This PR provides the configured HTTP endpoint presentation domain via the LiveLesson API, so that the web front-end doesn't have to coordinate the way it calculates this domain with antidote-core - it can simply use it. This change has been made in https://github.com/nre-learning/antidote-ui-components/pull/36.

Closes #169 