### PR TITLE
Add subnet to Connections configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## In development
 
-## v0.6.3 - June 04, 2020
-
 - Add capability to persist a session [#182](https://github.com/nre-learning/antidote-core/pull/182)
 - Move to Go Modules (finally) and fix txn functions [#191](https://github.com/nre-learning/antidote-core/pull/191)
 - Image Flavors [#189](https://github.com/nre-learning/antidote-core/pull/189)
+- Add subnet to Connections configuration [#194](https://github.com/nre-learning/antidote-core/pull/194)
 
 ## v0.6.2 - May 03, 2020
 

--- a/db/models/lesson.go
+++ b/db/models/lesson.go
@@ -82,8 +82,9 @@ type LessonPresentation struct {
 // LessonConnection is a point-to-point network connection between two LessonEndpoints. The `A` and `B` properties should
 // refer to the Name of LessonEndpoints within a given lesson that should be networked together.
 type LessonConnection struct {
-	A string `json:"A" yaml:"a" jsonschema:"required"`
-	B string `json:"B" yaml:"b" jsonschema:"required"`
+	A      string `json:"A" yaml:"a" jsonschema:"required"`
+	B      string `json:"B" yaml:"b" jsonschema:"required"`
+	Subnet string `json:"Subnet" yaml:"subnet" jsonschema:"required"`
 }
 
 // PresentationType is backed by a set of possible const values for presentation types below

--- a/scheduler/networks_test.go
+++ b/scheduler/networks_test.go
@@ -42,6 +42,7 @@ func TestNetworks(t *testing.T) {
 			span.Context(),
 			0,
 			"vqfx1-vqfx2",
+			"",
 			services.LessonScheduleRequest{
 				LiveLessonID: "asdf",
 			},
@@ -52,6 +53,6 @@ func TestNetworks(t *testing.T) {
 		err = json.Unmarshal([]byte(network.Spec.Config), &nc)
 		ok(t, err)
 
-		assert(t, nc.Ipam.Subnet == "10.10.0.0/16", "")
+		assert(t, nc.Ipam.Subnet == "169.0.0.0/16", "")
 	})
 }

--- a/scheduler/requests.go
+++ b/scheduler/requests.go
@@ -207,7 +207,7 @@ func (s *AntidoteScheduler) createK8sStuff(sc ot.SpanContext, req services.Lesso
 	// Create networks from connections property
 	for c := range lesson.Connections {
 		connection := lesson.Connections[c]
-		_, err := s.createNetwork(span.Context(), c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), req)
+		_, err := s.createNetwork(span.Context(), c, fmt.Sprintf("%s-%s-net", connection.A, connection.B), connection.Subnet, req)
 		if err != nil {
 			log.Error(err)
 			return err


### PR DESCRIPTION
This PR allows the lesson author to configue the subnet that's in use for a given multus network. While statically defined IP addresses are not possible in the traditional sense, this does allow authors to define a particular subnet for a given link, and addresses are allocated in order of consumption, which in this case is the order in which endpoints are listed - so they are deterministic.

More details will be added to the docs to explain this, but this PR is responsible for implementing this functionality by adding a "subnet" field to the `Connection` type in the lesson definition. This is an optional field, and the subnet will default to `169.0.0.0/16` if not provided.

Note that the existing rules about enforcement will still apply. While this does impact the addressing on each endpoint container, it's not enforced at a bridge level, and all multus interfaces are L2-aware. Meaning, if you are running a QEMU VM inside the container (like the vQFX) and connecting via a tap interface, you can still continue to send traffic using that address. None of that has changed, and will continue to be true. This PR only adds some configurability for the subnet that's in use on each link, which previously was baked into antidote and inacessible.