### PR TITLE
Add image meta option to enable IP forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Add image meta option to enable IP forwarding [#197](https://github.com/nre-learning/antidote-core/pull/197)
 - Remove subpath field from mount; copy only relevant subdirectory from lessons [#196](https://github.com/nre-learning/antidote-core/pull/196)
 - Add capability to persist a session [#182](https://github.com/nre-learning/antidote-core/pull/182)
 - Move to Go Modules (finally) and fix txn functions [#191](https://github.com/nre-learning/antidote-core/pull/191)

--- a/db/models/image.go
+++ b/db/models/image.go
@@ -10,13 +10,17 @@ import (
 
 // Image is a resource type that provides metadata for endpoint images in use within Lessons
 type Image struct {
-	Slug string `json:"Slug" yaml:"slug" jsonschema:"Unique identifier for this image,pattern=^[A-Za-z0-9\\-]*$"`
+	Slug string `json:"Slug" yaml:"slug" jsonschema:"description=Unique identifier for this image,pattern=^[A-Za-z0-9\\-]*$"`
 
-	Description string `json:"Description" yaml:"description" jsonschema:"Description of this image"`
+	Description string `json:"Description" yaml:"description" jsonschema:"description=Description of this image"`
 
 	// - "trusted" - regular container on the default runtime (i.e. runc), running in privileged mode. Should **only** be used sparingly, and only for images with its own virtualization layer
 	// - "untrusted" - provisioned with the kata runtimeclass, with no privileges or additional capabilities
 	Flavor ImageFlavor `json:"Flavor" yaml:"flavor" jsonschema:"required,enum=trusted,enum=untrusted"`
+
+	// This only enables forwarding at the container level. If this image uses the trusted flavor and is running a totally separate qemu VM, this will not affect the inner OS.
+	// Kata will forward sysctl calls, so this is mainly targeted at untrusted images that need to forward https://github.com/kata-containers/runtime/issues/185
+	EnableForwarding bool `json:"EnableForwarding" yaml:"enableForwarding" jsonschema:"description=Enable IP (v4 and v6) forwarding for this image at runtime"`
 
 	// Used to allow authors to know which interfaces are available, and in which order they'll be connected
 	NetworkInterfaces []string `json:"NetworkInterfaces" yaml:"networkInterfaces" jsonschema:"minItems=1"`


### PR DESCRIPTION
With the advent of image flavors (bringing runtimes like kata containers into the mix), it is not only possible but likely that there will now be simple container images that rely on certain kernel settings at the container or pod level. This PR introduces a flag within the image metadata to enable IP (v4 and v6) forwarding if needed.

Note that this is really only intended for "untrusted" images that run with Kata runtime. "trusted" images run their own virtual machine without any coordination between the pod and the guest OS, and already have full control of their own kernel, etc.