### PR TITLE
Start endpoint pods in the order provided in the lesson definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Start endpoint pods in the order provided in the lesson definition [#198](https://github.com/nre-learning/antidote-core/pull/198)
 - Add image meta option to enable IP forwarding [#197](https://github.com/nre-learning/antidote-core/pull/197)
 - Remove subpath field from mount; copy only relevant subdirectory from lessons [#196](https://github.com/nre-learning/antidote-core/pull/196)
 - Add capability to persist a session [#182](https://github.com/nre-learning/antidote-core/pull/182)


### PR DESCRIPTION
In #194 we added the ability for lesson authors to specify a subnet for each Connection object, which is passed to the IPAM CNI plugin, and all containers are automatically assigned addresses from that subnet in order of attachment. This isn't quite the same as just being able to pick which IP addresses get assigned to which endpoints, but my assumption was that because endpoints are provided as a YAML list, which is ordered, the endpoints would be spun up in a consistent order, and given the same addresses each time.

I **thought** I had tested this at the time to validate this assumption, but apparently I didn't, because I was wrong. Turns out that the livelesson API converts these endpoints to an unordered map to make it easier to look up endpoints by name, and this is pretty heavily embedded not only in the API (which impacts antidote-web) but also the internal data models. Since this is unordered by definition, this ensures that the attachment order, and in turn, any addressing assignments, are never consistent. This is obviously not what we want, as lesson guides and configurations will rely on this consistency.

As mentioned in a long comment, I **believe** this is the only place where endpoint order really matters, so rather than try to change the data type for this field, I added a little logic in this PR to iterate over the map in the original endpoint order from the lesson definition, which means endpoints will always be attached to these networks in a predictable order.

While this PR fixes this immediate issue, if I am proven wrong again, and we do end up requiring order preservation for other use cases, this workaround should be removed and we should just do the work of converting this field to a slice. This will require coordination between antidote-core and antidote-web.