### PR TITLE
Fix race bug in job completion check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Fix race bug in job completion check [#200](https://github.com/nre-learning/antidote-core/pull/200)
 - Add jupyter endpoint to ordered list after other lesson endpoints [#199](https://github.com/nre-learning/antidote-core/pull/199)
 - Start endpoint pods in the order provided in the lesson definition [#198](https://github.com/nre-learning/antidote-core/pull/198)
 - Add image meta option to enable IP forwarding [#197](https://github.com/nre-learning/antidote-core/pull/197)

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -22,7 +22,9 @@ import (
 )
 
 // JobBackoff controls the number of times a job is retried before we consider it failed.
-const JobBackoff = 2
+// I **believe** this is actually equal to the number of "tries", not "retries". So think of this as the number of pods you expect to see if
+// all of them failed.
+const JobBackoff = 3
 
 func (s *AntidoteScheduler) killAllJobs(sc ot.SpanContext, nsName, jobType string) error {
 
@@ -91,7 +93,7 @@ func (s *AntidoteScheduler) getJobStatus(span ot.Span, job *batchv1.Job, req ser
 			err
 	}
 
-	if result.Status.Failed >= JobBackoff+1 {
+	if result.Status.Failed >= JobBackoff {
 
 		// Get logs for failed configuration job/pod for troubleshooting purposes later
 		pods, err := s.Client.CoreV1().Pods(nsName).List(metav1.ListOptions{
@@ -128,12 +130,22 @@ func (s *AntidoteScheduler) getJobStatus(span ot.Span, job *batchv1.Job, req ser
 			nil
 	}
 
-	return (result.Status.Active == 0), map[string]int32{
+	if result.Status.Succeeded > 0 {
+		return true, map[string]int32{
+			"active":    result.Status.Active,
+			"succeeded": result.Status.Succeeded,
+			"failed":    result.Status.Failed,
+		}, nil
+	}
+
+	// If we got here, it means we didn't get enough failures yet, and it also means we didn't
+	// see any successes. This means we're not done yet, so we should return a false state, and no error,
+	// so the calling code can get another status after a wait.
+	return false, map[string]int32{
 		"active":    result.Status.Active,
 		"succeeded": result.Status.Succeeded,
 		"failed":    result.Status.Failed,
 	}, nil
-
 }
 
 func (s *AntidoteScheduler) configureEndpoint(sc ot.SpanContext, ep *models.LiveEndpoint, req services.LessonScheduleRequest) (*batchv1.Job, error) {

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -85,7 +85,11 @@ func (s *AntidoteScheduler) getJobStatus(span ot.Span, job *batchv1.Job, req ser
 	if err != nil {
 		span.LogFields(log.Error(err))
 		ext.Error.Set(span, true)
-		return false,
+
+		// The calling code **should** ignore the boolean status here, and instead just pass the error
+		// up the chain. So, it's not that important. However we're setting it to true just to ensure
+		// we don't keep trying.
+		return true,
 			map[string]int32{
 				"active":    0,
 				"succeeded": 0,

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -87,9 +87,9 @@ func (s *AntidoteScheduler) getJobStatus(span ot.Span, job *batchv1.Job, req ser
 		ext.Error.Set(span, true)
 		return false,
 			map[string]int32{
-				"active":    result.Status.Active,
-				"succeeded": result.Status.Succeeded,
-				"failed":    result.Status.Failed,
+				"active":    0,
+				"succeeded": 0,
+				"failed":    0,
 			},
 			err
 	}
@@ -117,18 +117,6 @@ func (s *AntidoteScheduler) getJobStatus(span ot.Span, job *batchv1.Job, req ser
 				"failed":    result.Status.Failed,
 			},
 			err
-	}
-
-	// If we call this too quickly, k8s won't have a chance to schedule the pods yet, and the final
-	// conditional will return true. So let's also check to see if failed or successful is 0
-	if result.Status.Active == 0 && result.Status.Failed == 0 && result.Status.Succeeded == 0 {
-		return false,
-			map[string]int32{
-				"active":    result.Status.Active,
-				"succeeded": result.Status.Succeeded,
-				"failed":    result.Status.Failed,
-			},
-			nil
 	}
 
 	if result.Status.Succeeded > 0 {

--- a/scheduler/jobs.go
+++ b/scheduler/jobs.go
@@ -24,6 +24,7 @@ import (
 // JobBackoff controls the number of times a job is retried before we consider it failed.
 // I **believe** this is actually equal to the number of "tries", not "retries". So think of this as the number of pods you expect to see if
 // all of them failed.
+// https://kubernetes.io/docs/concepts/workloads/controllers/job/
 const JobBackoff = 3
 
 func (s *AntidoteScheduler) killAllJobs(sc ot.SpanContext, nsName, jobType string) error {

--- a/scheduler/jobs_test.go
+++ b/scheduler/jobs_test.go
@@ -1,0 +1,146 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/jinzhu/copier"
+	"github.com/nre-learning/antidote-core/services"
+	ot "github.com/opentracing/opentracing-go"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestJobs(t *testing.T) {
+
+	req := services.LessonScheduleRequest{
+		LiveLessonID: "asdf",
+		LessonSlug:   "test-lesson",
+	}
+
+	s := createFakeScheduler()
+	nsName := generateNamespaceName(s.Config.InstanceID, req.LiveLessonID)
+
+	jobName := "configjob"
+	span := ot.StartSpan("test_db")
+	defer span.Finish()
+
+	backoff := int32(JobBackoff)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: nsName,
+			Labels: map[string]string{
+				"antidoteManaged": "yes",
+				"jobType":         "config",
+			},
+		},
+
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoff,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      jobName,
+					Namespace: nsName,
+					Labels: map[string]string{
+						"antidoteManaged": "yes",
+						"configPod":       "yes",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "configurator",
+							Image:           "antidotelabs/configurator",
+							Command:         []string{"foo"},
+							ImagePullPolicy: v1.PullAlways,
+						},
+					},
+					RestartPolicy: "Never",
+				},
+			},
+		},
+	}
+
+	_, err := s.Client.BatchV1().Jobs(nsName).Create(job)
+	ok(t, err)
+	result, err := s.Client.BatchV1().Jobs(nsName).Get(job.Name, metav1.GetOptions{})
+	ok(t, err)
+	equals(t, result.Namespace, "antidote-testing-asdf")
+	err = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+	ok(t, err)
+
+	// A new job with no status should return false with no error
+	t.Run("", func(t *testing.T) {
+		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+		_, err := s.Client.BatchV1().Jobs(nsName).Create(job)
+		ok(t, err)
+
+		completed, statusCount, err := s.getJobStatus(span, job, req)
+		ok(t, err)
+		equals(t, false, completed)
+		equals(t, map[string]int32{"active": 0, "failed": 0, "succeeded": 0}, statusCount)
+	})
+
+	// A job with at least one success should return true and no error
+	t.Run("", func(t *testing.T) {
+		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+		jobcopy := &batchv1.Job{}
+		copier.Copy(&jobcopy, &job)
+		jobcopy.Status.Succeeded = 1
+		_, err := s.Client.BatchV1().Jobs(nsName).Create(jobcopy)
+		ok(t, err)
+
+		completed, statusCount, err := s.getJobStatus(span, job, req)
+		ok(t, err)
+		equals(t, true, completed)
+		equals(t, map[string]int32{"active": 0, "failed": 0, "succeeded": 1}, statusCount)
+	})
+
+	// A job with a number of failures that is less than the backoff limit should return false with no error
+	t.Run("", func(t *testing.T) {
+		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+		jobcopy := &batchv1.Job{}
+		copier.Copy(&jobcopy, &job)
+		jobcopy.Status.Failed = 2
+		_, err := s.Client.BatchV1().Jobs(nsName).Create(jobcopy)
+		ok(t, err)
+
+		completed, statusCount, err := s.getJobStatus(span, job, req)
+		ok(t, err)
+		equals(t, false, completed)
+		equals(t, map[string]int32{"active": 0, "failed": 2, "succeeded": 0}, statusCount)
+	})
+
+	// A job with a number of failures that is equal to or greater than the backoff limit should return true with an error
+	t.Run("", func(t *testing.T) {
+		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+		jobcopy := &batchv1.Job{}
+		copier.Copy(&jobcopy, &job)
+		jobcopy.Status.Failed = 3
+		_, err := s.Client.BatchV1().Jobs(nsName).Create(jobcopy)
+		ok(t, err)
+
+		completed, statusCount, err := s.getJobStatus(span, job, req)
+		equals(t, true, completed)
+		assert(t, (err != nil), "")
+		equals(t, map[string]int32{"active": 0, "failed": 3, "succeeded": 0}, statusCount)
+	})
+
+	// A job with an improper namespace should cause a failure with all status count set to 0
+	t.Run("", func(t *testing.T) {
+		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
+		jobcopy := &batchv1.Job{}
+		copier.Copy(&jobcopy, &job)
+		jobcopy.Namespace = "foobar"
+		_, err := s.Client.BatchV1().Jobs("foobar").Create(jobcopy)
+		ok(t, err)
+
+		completed, statusCount, err := s.getJobStatus(span, job, req)
+		equals(t, false, completed)
+		assert(t, (err != nil), "")
+		equals(t, map[string]int32{"active": 0, "failed": 0, "succeeded": 0}, statusCount)
+	})
+
+}

--- a/scheduler/jobs_test.go
+++ b/scheduler/jobs_test.go
@@ -129,6 +129,7 @@ func TestJobs(t *testing.T) {
 	})
 
 	// A job with an improper namespace should cause a failure with all status count set to 0
+	// and a completed status of "true", just to indicate we shouldn't keep trying
 	t.Run("", func(t *testing.T) {
 		_ = s.Client.BatchV1().Jobs(nsName).Delete(job.Name, &metav1.DeleteOptions{})
 		jobcopy := &batchv1.Job{}
@@ -138,7 +139,7 @@ func TestJobs(t *testing.T) {
 		ok(t, err)
 
 		completed, statusCount, err := s.getJobStatus(span, job, req)
-		equals(t, false, completed)
+		equals(t, true, completed)
 		assert(t, (err != nil), "")
 		equals(t, map[string]int32{"active": 0, "failed": 0, "succeeded": 0}, statusCount)
 	})


### PR DESCRIPTION
This PR fixes a few things with respect to endpoint configuration.

# Fixing race condition in job completion check

Previously, I was checking to see if a job was completed by simply seeing if there were any active job pods. This is not a good way to check this, as the job controller will often wait for a few seconds before starting another job pod after a failure. If this check takes place in that intervening time, this check will cause antidote to mark a livelesson as ready before it is ready - and what's worse, is this lesson will likely not work because if one job pod fails, it's likely any further ones will too, which means the lesson environment will be presented to the learner, but not be properly prepped.

This PR changes this to a separate conditional to check if any pods have succeeded, and only then returning a "true" status. At the end of the function, I'm now returning a "false" status but with no errors, which will cause the calling code to treat this as simply "not ready yet", and will poll k8s again after a short sleep. This is a much better status check than relying on active pods.

# The Cake (`Backofflimit`) Is A Lie

The [kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) says:

> There are situations where you want to fail a Job after some amount of retries due to a logical error in configuration etc. To do so, set `.spec.backoffLimit` to specify the number of retries before considering a Job as failed.

For configuring endpoints, Antidote will set the backofflimit to a more reasonable value (from the default of 6) so that if there is a failure, it will not take forever to get that feedback to the learner. This is controlled by a constant in `jobs.go` called `JobBackoff`, and this is used to control the backoff limit passed to kubernetes as well as some other internal calculations. Previously, I had this set to 2, because I wanted a total of 3 attempts. The verbiage around retries seemed to indiicate to me that this was the number of pods **after** the first pod failed. However, because of the way I was doing the logic around checking completion before, sometimes we would get variation in the number of pods that it took to trigger a failure in Antidote.

I wanted to see what Kubernetes would do without the interference of Antidote, so I just created a job myself with a backofflimit set to 3:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: testjob
spec:
  backoffLimit: 3
  completions: 1
  parallelism: 1
  template:
    metadata:
      labels:
        job-name: testjob
      name: testjob
    spec:
      containers:
      - command:
        - exit 1
        image: antidotelabs/configurator:latest
        imagePullPolicy: Always
        name: configurator
        resources: {}
      dnsPolicy: ClusterFirst
      restartPolicy: Never
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
```

With a `backoffLimit` of `3` above, this results in the job creating three pods to attempt to run this job.

```
kp describe job testjob

Name:           testjob
Namespace:      default
Selector:       controller-uid=34c5f679-5ae9-4b44-9a02-9d4648d15156
Labels:         controller-uid=34c5f679-5ae9-4b44-9a02-9d4648d15156
                job-name=testjob
Annotations:    <none>
Parallelism:    1
Completions:    1
Start Time:     Tue, 28 Jul 2020 10:30:03 -0700
Pods Statuses:  0 Running / 0 Succeeded / 3 Failed
Pod Template:
  Labels:  controller-uid=34c5f679-5ae9-4b44-9a02-9d4648d15156
           job-name=testjob
  Containers:
   configurator:
    Image:      antidotelabs/configurator:latest
    Port:       <none>
    Host Port:  <none>
    Command:
      exit 1
    Environment:  <none>
    Mounts:       <none>
  Volumes:        <none>
Events:
  Type     Reason                Age   From            Message
  ----     ------                ----  ----            -------
  Normal   SuccessfulCreate      54s   job-controller  Created pod: testjob-dll8x
  Normal   SuccessfulCreate      51s   job-controller  Created pod: testjob-xxv4n
  Normal   SuccessfulCreate      41s   job-controller  Created pod: testjob-4pbm2
  Warning  BackoffLimitExceeded  1s    job-controller  Job has reached the specified backoff limit
```

For some reason I can't explain, when Antidote creates the job with the same parameters, it will create an extra pod attempt. So, in this PR I'm changing the `JobBackoff` constant to 3, and changing the logic on checking for failures to just check if there are failure pods **equal to or greater than** the `JobBackoff` constant. If K8s wants to create another one, it is welcome to do so. But Antidote will move on once that conditional is reached.
