### PR TITLE
Move networkpolicy creation to the beginning of the creation of livelesson resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Move networkpolicy creation to the beginning of the creation of livelesson resources  [#201](https://github.com/nre-learning/antidote-core/pull/201)
 - Fix race bug in job completion check [#200](https://github.com/nre-learning/antidote-core/pull/200)
 - Add jupyter endpoint to ordered list after other lesson endpoints [#199](https://github.com/nre-learning/antidote-core/pull/199)
 - Start endpoint pods in the order provided in the lesson definition [#198](https://github.com/nre-learning/antidote-core/pull/198)


### PR DESCRIPTION
Currently, the creation of a networkpolicy to restrict traffic from leaving the namespace is performed at the very end of a livelesson instantiation. This was done early on in antidote development, and I believe (if my memory serves me) that this was because we are not doing any match expressions to allow traffic from pods that are performing configuration steps.

Two things have changed since then - one, we are now using a more detailed policy to permit such traffic:

```go
MatchExpressions: []meta_v1.LabelSelectorRequirement{
	{
		Key:      "antidoteManaged",
		Operator: meta_v1.LabelSelectorOpIn,
		Values: []string{
			"yes",
		},
	},
	{ // do not apply network policy to config pods, they need to get to internet for configs
		Key:      "configPod",
		Operator: meta_v1.LabelSelectorOpNotIn,
		Values: []string{
			"yes",
		},
	},
},
```

Two, the main reason config pods needed to get to the internet is to clone the curriculum repo. This, of course, is no longer how Antidote does things.

So, for these two reasons, this PR moves the creation of the networkpolicy object so that it happens before anything else. This means that in the event a lesson fails to start for any reason, the networkpolicy will still be there.