### PR TITLE
Add (deprecated) 'legacy' image flavor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Add (deprecated) 'legacy' image flavor [#202](https://github.com/nre-learning/antidote-core/pull/202)
 - Move networkpolicy creation to the beginning of the creation of livelesson resources  [#201](https://github.com/nre-learning/antidote-core/pull/201)
 - Fix race bug in job completion check [#200](https://github.com/nre-learning/antidote-core/pull/200)
 - Add jupyter endpoint to ordered list after other lesson endpoints [#199](https://github.com/nre-learning/antidote-core/pull/199)

--- a/cmd/antictl/main.go
+++ b/cmd/antictl/main.go
@@ -139,7 +139,7 @@ func main() {
 						client := pb.NewLiveSessionsServiceClient(conn)
 
 						if len(c.Args()) < 2 {
-							fmt.Println("Missing args to command : antictl livesession persist <true/false> <session id>")
+							fmt.Println("Missing args to command : antictl livesession persist <session id> <true/false>")
 							os.Exit(1)
 						}
 

--- a/db/models/image.go
+++ b/db/models/image.go
@@ -16,7 +16,8 @@ type Image struct {
 
 	// - "trusted" - regular container on the default runtime (i.e. runc), running in privileged mode. Should **only** be used sparingly, and only for images with its own virtualization layer
 	// - "untrusted" - provisioned with the kata runtimeclass, with no privileges or additional capabilities
-	Flavor ImageFlavor `json:"Flavor" yaml:"flavor" jsonschema:"required,enum=trusted,enum=untrusted"`
+	// - "legacy" - (deprecated) meant to provide a way to get the "old" style of doing things if needed, but use of this should be avoided.
+	Flavor ImageFlavor `json:"Flavor" yaml:"flavor" jsonschema:"required,enum=legacy,enum=trusted,enum=untrusted"`
 
 	// This only enables forwarding at the container level. If this image uses the trusted flavor and is running a totally separate qemu VM, this will not affect the inner OS.
 	// Kata will forward sysctl calls, so this is mainly targeted at untrusted images that need to forward https://github.com/kata-containers/runtime/issues/185
@@ -35,6 +36,7 @@ type Image struct {
 type ImageFlavor string
 
 const (
+	FlavorLegacy    ImageFlavor = "legacy"
 	FlavorTrusted   ImageFlavor = "trusted"
 	FlavorUntrusted ImageFlavor = "untrusted"
 )

--- a/scheduler/pods.go
+++ b/scheduler/pods.go
@@ -171,6 +171,22 @@ func (s *AntidoteScheduler) createPod(sc ot.SpanContext, ep *models.LiveEndpoint
 				},
 			},
 		}
+
+	// DEPRECATED - this is the "old" unprivileged model. Shouldn't be needed, but for the time being I'd
+	// rather have it and not need it vs the reverse. Provided the new flavor model works, this can be removed
+	// as an option after a while.
+	case models.FlavorLegacy:
+		t := false
+		pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+			Privileged:               &t,
+			AllowPrivilegeEscalation: &t,
+			Capabilities: &corev1.Capabilities{
+				Add: []corev1.Capability{
+					"NET_ADMIN",
+				},
+			},
+		}
+
 	default:
 
 		t := false


### PR DESCRIPTION
The two flavors currently supported "trusted" and "untrusted" should be sufficient for everything currently in the NRE Labs curriculum (I have just finished going through testing everything on this new paradigm).

However, this is a pretty big architectural shift, and in the event that for some reason things don't work out, I'd like to have an option to fall back to the old way of doing things (no privileges, default runtime). Currently there is no option to do this. So, I'm introducing the `legacy` flavor to do this in case we need it.

I'm creating it as "deprecated" to help indicate I don't intend to keep it around long-term.