### PR TITLE
Adding experimental ready delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In development
 
+- Adding experimental ready delay [#206](https://github.com/nre-learning/antidote-core/pull/206)
 - Convert networkpolicy to use blank namespace selector instead of RFC1918 [#205](https://github.com/nre-learning/antidote-core/pull/205)
 - Upgrade grpc-gateway and add required protobuf options [#204](https://github.com/nre-learning/antidote-core/pull/204)
 - Add (deprecated) 'legacy' image flavor [#202](https://github.com/nre-learning/antidote-core/pull/202)

--- a/api/exp/definitions/lesson.proto
+++ b/api/exp/definitions/lesson.proto
@@ -66,6 +66,7 @@ message Lesson {
   string ShortDescription = 17;
   string LessonFile = 18;
   string LessonDir = 19;
+  int32 ReadyDelay = 20;
 }
 
 message LessonFilter {

--- a/api/exp/definitions/lesson.swagger.json
+++ b/api/exp/definitions/lesson.swagger.json
@@ -230,6 +230,10 @@
         },
         "LessonDir": {
           "type": "string"
+        },
+        "ReadyDelay": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },

--- a/api/exp/swagger/swagger.pb.go
+++ b/api/exp/swagger/swagger.pb.go
@@ -654,6 +654,10 @@ Lesson = `{
         },
         "LessonDir": {
           "type": "string"
+        },
+        "ReadyDelay": {
+          "type": "integer",
+          "format": "int32"
         }
       }
     },

--- a/db/models/lesson.go
+++ b/db/models/lesson.go
@@ -26,6 +26,9 @@ type Lesson struct {
 	Connections      []*LessonConnection `json:"Connections,omitempty" yaml:"connections,omitempty" jsonschema:"description=(Connections between endpoints in the topology)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/connections"`
 	Authors          []*LessonAuthor     `json:"Authors,omitempty" yaml:"authors,omitempty" jsonschema:"description=(A list of individuals that have contributed to this lesson)\nhttps://docs.nrelabs.io/antidote/object-reference/lessons/authors"`
 
+	// Experimental field for adding a short delay before marking the lesson ready, to help deal with some SSH instability for images that have processes still starting.
+	ReadyDelay int `json:"-" yaml:"readyDelay,omitempty" jsonschema:"-"`
+
 	// NOTE - any time you see these dashes, it means this field is used for internal purposes only.
 	// When we were using protobuf models for everything, we couldn't do this. But by separating internal
 	// models from API models, we can still mark a field like this while still being able to offer it via API.


### PR DESCRIPTION
Some images may have connectivity instability while starting, even after passing the initial health check. For instance, an image might want to start sshd, and then some other background process which slams the CPU for a few seconds, causing the container to lose connectivity for a short time. With the right timing, this could cause a lesson to go into the READY state, and be presented to the user, and quickly become disconnected, forcing the user to refresh, maybe multiple times.

I'm planning to tackle this with some more lenient timeouts in WebSSH as well, but I wanted to add (for now) an experimental field to just delay that final READY state by some number of seconds, defined in the lesson metadata. It's experimental for now and absolutely a hack, so it shouldn't be relied upon if at all possible.