### PR TITLE
Add ability to configure additional network interface names in image meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Refactored scheduler for Pluggable Backends [#212](https://github.com/nre-learning/antidote-core/pull/212)
 - Adding developer mode [#209](https://github.com/nre-learning/antidote-core/pull/209)
-- Add ability to configure additional network interface names in imag meta [#214](https://github.com/nre-learning/antidote-core/pull/214)
+- Add ability to configure additional network interface names in image meta [#214](https://github.com/nre-learning/antidote-core/pull/214)
 
 ## v0.7.0 - December 14, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Refactored scheduler for Pluggable Backends [#212](https://github.com/nre-learning/antidote-core/pull/212)
 - Adding developer mode [#209](https://github.com/nre-learning/antidote-core/pull/209)
+- Add ability to configure additional network interface names in imag meta [#214](https://github.com/nre-learning/antidote-core/pull/214)
 
 ## v0.7.0 - December 14, 2020
 

--- a/db/ingestors/images.go
+++ b/db/ingestors/images.go
@@ -54,6 +54,10 @@ func ReadImages(cfg config.AntidoteConfig) ([]*models.Image, error) {
 			log.Errorf("Failed to import %s: %s", file, err)
 		}
 
+		if image.NetworkInterfaces == nil {
+			image.NetworkInterfaces = []string{}
+		}
+
 		err = validateImage(&image)
 		if err != nil {
 			log.Errorf("Image '%s' failed to validate", image.Slug)
@@ -85,7 +89,7 @@ func validateImage(image *models.Image) error {
 
 	for i := range image.NetworkInterfaces {
 		if image.NetworkInterfaces[i] == "eth0" {
-			log.Error("No presentations configured, and no additionalPorts specified")
+			log.Error("Not allowed to specify eth0 in networkInterfaces list")
 			return errEth0NotAllowed
 		}
 	}

--- a/db/ingestors/images.go
+++ b/db/ingestors/images.go
@@ -83,5 +83,12 @@ func validateImage(image *models.Image) error {
 		return errBasicValidation
 	}
 
+	for i := range image.NetworkInterfaces {
+		if image.NetworkInterfaces[i] == "eth0" {
+			log.Error("No presentations configured, and no additionalPorts specified")
+			return errEth0NotAllowed
+		}
+	}
+
 	return nil
 }

--- a/db/ingestors/images_test.go
+++ b/db/ingestors/images_test.go
@@ -46,7 +46,15 @@ func TestNoNetworkInterfaces(t *testing.T) {
 	i.NetworkInterfaces = []string{}
 	err := validateImage(&i)
 
-	assert(t, (err == errBasicValidation), "Expected errBasicValidation")
+	assert(t, (err == nil), "Expected no error; the NetworkInterfaces field is optional")
+}
+
+func TestInvalidNetworkInterface(t *testing.T) {
+	i := getValidImage()
+	i.NetworkInterfaces = []string{"eth0", "net1"}
+	err := validateImage(&i)
+
+	assert(t, (err == errEth0NotAllowed), "Expected errEth0NotAllowed")
 }
 
 func TestNoSSHUser(t *testing.T) {

--- a/db/ingestors/ingestors.go
+++ b/db/ingestors/ingestors.go
@@ -20,4 +20,7 @@ var (
 	errDuplicatePresentation    = errors.New("Duplicate presentations detected")
 	errBadConnection            = errors.New("Malformed connection")
 	errMissingLessonGuide       = errors.New("Couldn't find/read lesson guide")
+
+	// Images-Specific Errors
+	errEth0NotAllowed = errors.New("Not allowed to include 'eth0' in NetworkInterfaces field of images")
 )

--- a/db/models/image.go
+++ b/db/models/image.go
@@ -23,8 +23,8 @@ type Image struct {
 	// Kata will forward sysctl calls, so this is mainly targeted at untrusted images that need to forward https://github.com/kata-containers/runtime/issues/185
 	EnableForwarding bool `json:"EnableForwarding" yaml:"enableForwarding" jsonschema:"description=Enable IP (v4 and v6) forwarding for this image at runtime"`
 
-	// Used to allow authors to know which interfaces are available, and in which order they'll be connected
-	NetworkInterfaces []string `json:"NetworkInterfaces" yaml:"networkInterfaces" jsonschema:"minItems=1"`
+	// Used to specify names for additional network interfaces (not including "eth0")
+	NetworkInterfaces []string `json:"NetworkInterfaces" yaml:"networkInterfaces" jsonschema:"minItems=0"`
 
 	SSHUser     string `json:"SSHUser" yaml:"sshUser" jsonschema:"minLength=1,description=Username for SSH connections"`
 	SSHPassword string `json:"SSHPassword" yaml:"sshPassword" jsonschema:"minLength=1,Password for SSH Connections"`

--- a/db/test/test-curriculum/images/utility/image.meta.yaml
+++ b/db/test/test-curriculum/images/utility/image.meta.yaml
@@ -9,4 +9,4 @@ sshPassword: antidotepassword
 configUser: antidote
 configPassword: antidotepassword
 networkInterfaces:
-  - 'eth0'
+  - 'net1'

--- a/hack/mocks/images/utility/image.meta.yaml
+++ b/hack/mocks/images/utility/image.meta.yaml
@@ -2,7 +2,7 @@ slug: utility
 description: A utility image
 privileged: false
 networkInterfaces:
-  - 'eth0'
+  - 'net1'
 sshUser: antidote
 flavor: untrusted
 sshPassword: antidotepassword


### PR DESCRIPTION
The `networkInterfaces` field in the image metadata was created long ago, but currently does nothing. The idea at the time was to use this purely as a descriptive field, so that lesson authors could know which network interfaces to expect a given image to use. 

However, Multus gives the ability to configure interface names when attaching pods to a network, so we can go beyond simply describing defaults - we can use this as a way of overriding those defaults, and set interface names at attachment time. This makes it possible to accommodate images that expect certain interface names, as described in https://github.com/nre-learning/nrelabs-curriculum/issues/339

The field is now optional, but when present, will be used to specify the name of all interfaces following `eth0`, and will be consumed in order of the networks a pod is attached to. 